### PR TITLE
Decouple database library from transaction logic

### DIFF
--- a/lib/DatabaseLibrary.js
+++ b/lib/DatabaseLibrary.js
@@ -17,7 +17,6 @@ async function connectToDB() {
     }
 }
 
-
 async function rollbackAndLog(db, failures, fileName, errMessage, funcName) {
     await db.rollback();
     failures.push({

--- a/lib/SongDatabaseLibrary.js
+++ b/lib/SongDatabaseLibrary.js
@@ -1,9 +1,10 @@
 const mysql = require('mysql');
-const Connection = require('mysql/lib/Connection');
 const Logger = require('../utils/Logger.js');
 
+// all paths stored in DB are relative to this URL
 const rootURL = 'http://api.ragtagrecords.com/public/songs';
 
+// Update songFormatted when we want additional rows from DB
 function formatSongsJSON(songs) {
     let songsFormatted = [];
     let i = 0;
@@ -12,8 +13,9 @@ function formatSongsJSON(songs) {
             id: song.id,
             name: song.name,
             path: rootURL + song.path,
-            artist: song.artists ? song.artist : '',
-            tempo: song.tempo ? song.tempo : ''
+            artist: song.artists ?? '',
+            tempo: song.tempo ?? '',
+            createTimestamp: song.createTimestamp ?? ''
         };
 
         songsFormatted.push(songFormatted);
@@ -21,25 +23,21 @@ function formatSongsJSON(songs) {
     return songsFormatted;
 }
 
-// TODO: convert rest of functions in public.js to use DatabaseLibrary::connectToDB() instead of this
-async function createDBConnection() {
-    const db = await mysql.createConnection({
-        user: "audiofiler-fs",
-        host: "150.238.75.231",
-        password: "weloveclouddatabasesolutions",
-        database: "audiofiler"
-    });
+function formatPlaylistsJSON(playlists) {
+    let playlistsFormatted = [];
+    let i = 0;
+    playlists.forEach(playlist => {
+        const playlistFormatted = {
+            id: playlist.id,
+            name: playlist.name
+        };
 
-    if (db) {
-        await db.beginTransaction()
-        return db;
-    } else {
-        Logger.logError('createDBConnection()', "Couldn't connect to database");
-        return false;
-    }
+        playlistsFormatted.push(playlistFormatted);
+    });
+    return playlistsFormatted;
 }
 
-function addSong(path, name, tempo, db) {
+function addSong(db, path, name, tempo) {
     return new Promise(async resolve => {
         await db.query(
             `INSERT INTO songs (path, name, tempo) VALUES (?,?,?)`,
@@ -61,7 +59,7 @@ function addSong(path, name, tempo, db) {
     });
 }
 
-function addSongPlaylist(songID, playlistID, db) {
+function addSongPlaylist(db, songID, playlistID) {
 
     if(!songID || !playlistID || !db) {
         return false;
@@ -110,30 +108,20 @@ function addPlaylist(db, name) {
     });
 }
 
-// TODO: probably should change this to work like getSongs and getSongPlaylists
-// basically stop creating/ending/rollback db connection here
-function getAllSongs() {
+function getAllSongs(db) {
     return new Promise(async resolve => {
-        const db = await createDBConnection();
-
         await db.query(
             `SELECT * FROM songs`,
             [],
             (err, songs) => {
                 if (err) {
                     Logger.logError('getAllSongs()', err.sqlMessage ?? "Database Error, No message found");
-                    db.rollback();
-                    db.end();
                     resolve(false);
                 } else {
-                    db.commit();
-                    db.end();
-
                     Logger.logSuccess(
                         'getAllSongs',
                         'Returned all songs from database' 
                     );
-                    
                     resolve(formatSongsJSON(songs));
                 }
             }
@@ -142,31 +130,21 @@ function getAllSongs() {
     });
 }
 
-// TODO: probably should change this to work like getSongs and getSongPlaylists
-// basically stop creating/ending/rollback db connection here
-function getAllPlaylists() {
+function getAllPlaylists(db) {
     return new Promise(async resolve => {
-        const db = await createDBConnection();
-
         await db.query(
             `SELECT * FROM playlists`,
             [],
-            (err, songs) => {
+            (err, playlists) => {
                 if (err) {
                     Logger.logError('getAllPlaylists()', err.sqlMessage ?? "Database Error, No message found");
-                    db.rollback();
-                    db.end();
                     resolve(false);
                 } else {
-                    db.commit();
-                    db.end();
-
                     Logger.logSuccess(
                         'getAllPlaylists()',
                         'Returned all playlists from database' 
                     );
-                    
-                    resolve(formatSongsJSON(songs));
+                    resolve(formatPlaylistsJSON(playlists));
                 }
             }
         );
@@ -174,34 +152,22 @@ function getAllPlaylists() {
     });
 }
 
-
-// TODO: probably should change this to work like getSongs and getSongPlaylists
-// basically stop creating/ending/rollback db connection here
-function getSongsByPlaylistID(playlistID) {
+function getSongsByPlaylistID(db, playlistID) {
     return new Promise(async resolve => {
-        const db = await createDBConnection();
-
         await db.query(
-            `SELECT songs.id, songs.path, songs.name, songs.tempo, songs.artist, songPlaylists.playlistID
-            FROM songs
+            `SELECT * FROM songs
             INNER JOIN songPlaylists ON songs.id = songPlaylists.songID
             WHERE songPlaylists.playlistID = ?;`,
             [playlistID],
             (err, songs) => {
                 if (err) {
                     Logger.logError('getSongsByPlaylist()', err.sqlMessage ?? "Database Error, No message found");
-                    db.rollback();
-                    db.end();
                     resolve(false);
                 } else {
-                    db.commit();
-                    db.end();
-
                     Logger.logSuccess(
                         'getSongsByPlaylist()',
                         'Returned playlist ' + playlistID + ' successfully' 
                     );
-                    
                     resolve(formatSongsJSON(songs));
                 }
             }


### PR DESCRIPTION
basically, stop creating/ending db connections and doing transaction stuff inside the library

the functions calling the library should create there own db and manage the transactions, the library just does the db query

this allows for multiple queries to be done on same transaction